### PR TITLE
Prevent ClientConnection from generating exponentially growing error logs for connection failures via cascadingly spawned new instances

### DIFF
--- a/src/client/client-connection.ts
+++ b/src/client/client-connection.ts
@@ -12,6 +12,8 @@ export class ClientConnection extends Connection {
         super();
         this.config = deps.config;
         this.broadcaster = deps.broadcaster;
+
+        this.broadcaster.on('__transmit__', (payload: Payload) => this.send(payload));
     }
 
     async init() {
@@ -34,7 +36,7 @@ export class ClientConnection extends Connection {
             this.socket.onerror = (error) => {
                 console.error('Error connecting to server', error);
                 resolve()
-                this.reconnect();
+                this.socket?.close();
             }
             this.socket.onmessage = (message) => {
                 try {
@@ -45,8 +47,6 @@ export class ClientConnection extends Connection {
                 }
             }
         });
-
-        this.broadcaster.on('__transmit__', (payload: Payload) => this.send(payload));
     }
 
     destroy() {


### PR DESCRIPTION
I found a bug in our ClientConnection's onerror-code that on connection failure seems to cumulatively spawn new extra connections every 5s, which leads to exponentially growing error log messages, eventually halting completely the Safari's Web Inspector Console and Sources views even in MacBook Pro. The cascading error log bug disappears when I comment this.reconnect(); line. I managed to find a small solution.

