### PR TITLE
Glaze-49 Control 4 motors simultaneously using Mission Control

### DIFF
--- a/src/modules/control/class/ECMMotorState.ts
+++ b/src/modules/control/class/ECMMotorState.ts
@@ -3,10 +3,11 @@ import { MotorState } from './MotorState';
 import { Logger } from 'src/logger';
 
 export class ECMMotorState extends MotorState {
-    gpioOutPWM: Pwm;// GPIO for the motor speed
-    gpioOutReverse: Output; // GPIO for the motor reversing
-    gpioOutStop: Output; // GPIO for the motor stopping (when 0% power duty cycle cannot stop it)
+    gpioOutPWM: Pwm | number;
+    gpioOutReverse: Output | number;
+    gpioOutStop: Output | number;
     invertPWM: boolean; // Invert the PWM signal, useful for certain motor drivers
+    invertPWMWithDirection: boolean; // Invert PWM when direction is reversed
     invertRotationDirection: boolean; // Invert the rotation direction of the motor
     
     constructor({
@@ -16,27 +17,32 @@ export class ECMMotorState extends MotorState {
         gpioOutReverse: gpioOutReverse,
         gpioOutStop: gpioOutStop,
         invertPWM: invertPWM,
+        invertPWMWithDirection: invertPWMWithDirection,
         invertRotationDirection: invertRotationDirection,
         rampSpeed: rampSpeed,
         position: position,
         orientation: orientation,
+        scale: scale,
     }: {
         name: string;
         logger: Logger;
-        gpioOutPWM?: Pwm; 
-        gpioOutReverse?: Output;
-        gpioOutStop?: Output;
+        gpioOutPWM?: Pwm | number;
+        gpioOutReverse?: Output | number;
+        gpioOutStop?: Output | number;
         invertPWM?: boolean;
+        invertPWMWithDirection?: boolean;
         invertRotationDirection?: boolean;
         rampSpeed?: number;
         position?: number[];
         orientation?: number[];
+        scale?: number;
     }) {
-        super({name: name, logger: logger, rampSpeed: rampSpeed, position: position, orientation: orientation});
+        super({name: name, logger: logger, rampSpeed: rampSpeed, position: position, orientation: orientation, scale: scale});
         this.gpioOutPWM = gpioOutPWM;
         this.gpioOutReverse = gpioOutReverse;
         this.gpioOutStop = gpioOutStop;
         this.invertPWM = invertPWM || false;
+        this.invertPWMWithDirection = invertPWMWithDirection || false;
         this.invertRotationDirection = invertRotationDirection || false;
     }
 
@@ -50,21 +56,39 @@ export class ECMMotorState extends MotorState {
                 if (Math.abs(this.targetPower - this.power) < 0.01) {
                     this.power = this.targetPower; // Snap to target if close enough
                 }
-                if (this.gpioOutPWM) {
+                if (typeof this.gpioOutPWM !== 'undefined') {
+                    let dutyCycle = Math.abs(this.power);
                     if (this.invertPWM) {
-                        this.gpioOutPWM.setDutyCycle(1 - Math.abs(this.power));
-                    } else {
-                        this.gpioOutPWM.setDutyCycle(Math.abs(this.power));
+                        dutyCycle = 1 - dutyCycle;
                     }
-                    if (this.gpioOutReverse) {
-                        if (!this.invertRotationDirection) {
-                            this.gpioOutReverse.value = this.power < 0;
-                        }  else {
-                            this.gpioOutReverse.value = this.power > 0;
+                    if (this.invertPWMWithDirection && this.power < 0) {
+                        dutyCycle = 1 - dutyCycle;
+                    }
+                    if (this.gpioOutPWM instanceof Pwm) {
+                        this.gpioOutPWM.setDutyCycle(dutyCycle);
+                    }
+                    else if (MotorState.pwmModule) {
+                        MotorState.pwmModule.setDutyCycle(this.gpioOutPWM, dutyCycle);
+                    }
+                    if (typeof this.gpioOutReverse !== 'undefined') {
+                        let reverse = this.power < 0;
+                        if (this.invertRotationDirection) {
+                            reverse = this.power > 0;
+                        }
+                        if (this.gpioOutReverse instanceof Output) {
+                            this.gpioOutReverse.value = reverse;
+                        }
+                        else if (MotorState.pwmModule) {
+                            MotorState.pwmModule.setDutyCycle(this.gpioOutReverse, reverse ? 1 : 0);
                         }
                     }
-                    if (this.gpioOutStop) {
-                        this.gpioOutStop.value = this.power != 0;
+                    if (typeof this.gpioOutStop !== 'undefined') {
+                        if (this.gpioOutStop instanceof Output) {
+                            this.gpioOutStop.value = this.power != 0;
+                        }
+                        else if (MotorState.pwmModule) {
+                            MotorState.pwmModule.setDutyCycle(this.gpioOutStop, this.power != 0 ? 1 : 0);
+                        }
                     }
                 }
                 this.emit('setPower', this.power);

--- a/src/modules/control/server.ts
+++ b/src/modules/control/server.ts
@@ -3,7 +3,7 @@ import { ServerModuleDependencies } from 'src/server/server';
 import { MotorState } from './class/MotorState';
 import { ECMMotorState } from './class/ECMMotorState';
 import { Wrench } from './types';
-import { OrangePi_5 } from 'opengpio';
+// import { OrangePi_5 } from 'opengpio';
 import { cross, subtract, pi, sin, cos, multiply, pinv, transpose, round } from 'mathjs';
 
 const isProd = false; // process.env.NODE_ENV === 'production';
@@ -14,8 +14,8 @@ export class ControlModuleServer extends Module {
         rear: new ECMMotorState({
             name: 'Rear Motor',
             logger: this.logger,
-            // gpioOutPWM: OrangePi_5.pwm(OrangePi_5.bcm.GPIO1_A3, 1, 500),
-            // gpioOutStop: OrangePi_5.output(OrangePi_5.bcm.GPIO1_A4),
+            gpioOutPWM: 6, // OrangePi_5.pwm(OrangePi_5.bcm.GPIO1_A3, 1, 500),
+            gpioOutStop: 7, // OrangePi_5.output(OrangePi_5.bcm.GPIO1_A4),
             invertPWM: true,
             position: [0, 0.5, -2.5],
             orientation: [0, 0, 1], // Right-hand rule (Z forward)
@@ -23,17 +23,19 @@ export class ControlModuleServer extends Module {
         rearTransverse: new ECMMotorState({
             name: 'Medium Motor',
             logger: this.logger,
-            // gpioOutPWM: OrangePi_5.pwm(OrangePi_5.bcm.GPIO1_D1, 1, 500),
-            // gpioOutReverse: OrangePi_5.output(OrangePi_5.bcm.GPIO1_A7),
+            gpioOutPWM: 4, // OrangePi_5.pwm(OrangePi_5.bcm.GPIO1_D1, 1, 500),
+            gpioOutReverse: 5, // OrangePi_5.output(OrangePi_5.bcm.GPIO1_A7),
             invertPWM: true,
+            scale: 4,
             position: [0, 0.54, -1.93],
             orientation: [1, 0, 0], // Right-hand rule (X left)
         }),
         leftWing: new ECMMotorState({
             name: 'Small Motor Left',
             logger: this.logger,
-            // gpioOutPWM: OrangePi_5.pwm(OrangePi_5.bcm.GPIO1_A2, 0, 500),
-            // gpioOutReverse: OrangePi_5.output(OrangePi_5.bcm.GPIO1_A6),
+            gpioOutPWM: 0, // OrangePi_5.pwm(OrangePi_5.bcm.GPIO1_A2, 0, 500),
+            gpioOutReverse: 1, // OrangePi_5.output(OrangePi_5.bcm.GPIO1_A6),
+            scale: 2,
             invertRotationDirection: true,
             position: [0.66, 0.36, -0.49],
             orientation: [sin(this.wingAngleInDegrees * (pi / 180)), cos(this.wingAngleInDegrees * (pi / 180)), 0],
@@ -41,6 +43,9 @@ export class ControlModuleServer extends Module {
         rightWing: new ECMMotorState({
             name: 'Small Motor Right',
             logger: this.logger,
+            gpioOutPWM: 2,
+            gpioOutReverse: 3,
+            scale: 2,
             position: [-0.66, 0.36, -0.49],
             orientation: [sin(this.wingAngleInDegrees * (pi / 180)), -cos(this.wingAngleInDegrees * (pi / 180)), 0],
         }),
@@ -134,7 +139,7 @@ export class ControlModuleServer extends Module {
         }
         mappingMatrix = transpose(mappingMatrix);
         this.logger.info(`Mapping matrix: ${JSON.stringify(round(mappingMatrix, 2))}`);
-        let inverseMappingMatrix = pinv(mapping_matrix); // To be recomputed if motors change: stuck or broken
+        let inverseMappingMatrix = pinv(mappingMatrix); // To be recomputed if motors change: stuck or broken
         this.logger.info(`Moore-Penrose-inverted mapping matrix: ${JSON.stringify(round(inverseMappingMatrix, 2))}`);
         this.virtualToPhysical = {};
         const virtualKeys = Object.keys(this.virtualMotors);

--- a/src/modules/lights/server.ts
+++ b/src/modules/lights/server.ts
@@ -3,55 +3,48 @@ import { PCA9685 } from 'openi2c';
 import { ServerModuleDependencies } from 'src/server/server';
 
 export class LightsModuleServer extends Module {
-    private pwmModule?: PCA9685;
-    private frequency = 200;
-    private bus = 1;
-    private pwmModuleRanInit = false;
+    private pwmModule: PCA9685;
 
     constructor(deps: ServerModuleDependencies) {
         super(deps);
-        // Uncomment the following line to enable PCA9685 control.
-        // this.pwmModule = new PCA9685(this.bus);
+        let bus = 4;
+        let frequency = 4096;
+        if (!this.pwmModule) {
+            // Uncomment the following line to enable PCA9685 control.
+            // this.pwmModule = new PCA9685(bus);
+            this.pwmModule?.init().then(() => {
+                this.pwmModule?.setFrequency(frequency)
+                    .then(() => {
+                        this.logger.info(`PCA9685 initialized at ${frequency}Hz on bus ${bus}`);
+                    })
+                    .catch((err) => {
+                        this.logger.error('Failed to set PCA9685 frequency', err);
+                    });
+            });
+        }
     }
 
     onModuleInit(): void | Promise<void> {
-        if (!this.pwmModule) {
-            return;
-        }
-
-        this.pwmModule.init().then(() => {
-            this.pwmModuleRanInit = true;
-            this.pwmModule.setFrequency(this.frequency)
-                .then(() => {
-                    this.logger.info(`PCA9685 initialized at ${this.frequency}Hz on bus ${this.bus}`);
-                })
-                .catch((err) => {
-                    this.logger.error('Failed to set PCA9685 frequency', err);
-                });
-        });
-
         this.on('setLight', async (data: { type: 'vis' | 'ir' | 'uv'; brightness: number }) => {
-            if (!this.pwmModuleRanInit) {
-                console.warn('PCA9685 not initialized yet');
-                return;
-            }
             let channel: number; // Channel is PWM module output channel.
             switch (data.type) {
                 case 'vis':
-                    channel = 0;
+                    channel = 12;
                     break;
                 case 'ir':
-                    channel = 1;
+                    channel = 13;
                     break;
                 case 'uv':
-                    channel = 2;
+                    channel = 14;
                     break;
                 default:
                     console.warn(`Unknown light type: ${data.type}`);
                     return;
             }
             const brightness = Math.min(1, Math.max(0, data.brightness));
-            await this.pwmModule.setDutyCycle(channel, brightness);
+            if (this.pwmModule) {
+                await this.pwmModule.setDutyCycle(channel, brightness);
+            }
         });
     }
 }


### PR DESCRIPTION
Instead of software PWM use hardware PWM via external PCA9685 module.

(Also refactor Lights module to match that of Control module.)